### PR TITLE
linenoiseRemoteRefereshLine()

### DIFF
--- a/linenoise.h
+++ b/linenoise.h
@@ -65,6 +65,7 @@ int linenoiseHistoryLoad(const char *filename);
 void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);
+void linenoiseRemoteRefreshLine(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When other processes call printf and linenoise had a prompt displayed,
the text gets printed after the prompt and looks horrible.

This function allows other processes to remotely refresh the linenoise
line. Thereby they can print their string on its own line, then reshesh
the prompt so everything looks nice.

This is accomplished by replacing read in several places with a function
that uses select to wait on two file descriptors, stdin and a control
pipe that we create. linenoiseRemoteRefreshLine() pushes a new control
character (ctrl-r) into our control pipe; when that is received, a flag
is set that calls for refresh line to be called.